### PR TITLE
Fix main section button style

### DIFF
--- a/app/routes/($locale)._index.tsx
+++ b/app/routes/($locale)._index.tsx
@@ -67,7 +67,7 @@ function MainSection() {
       <div className="absolute bottom-20 right-20 z-10">
         <Link
           to="/collections/all"
-          className="px-10 py-5 text-base font-semibold tracking-wide border border-white text-white bg-transparent hover:bg-white hover:text-black hover:shadow-lg transition-all duration-300 rounded-xl backdrop-blur-lg no-underline hover:no-underline"
+          className="mainsection-btn px-10 py-5 text-base font-semibold tracking-wide border border-white bg-transparent hover:bg-white hover:shadow-lg transition-all duration-300 rounded-xl backdrop-blur-lg"
         >
           Discover the Collection
         </Link>

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -539,3 +539,18 @@ button.reset:hover:not(:has(> *)) {
 .account-logout {
   display: inline-block;
 }
+
+/*
+* --------------------------------------------------
+* custom styles for MainSection button
+* --------------------------------------------------
+*/
+.mainsection-btn {
+  text-decoration: none !important;
+  color: #fff !important;
+}
+
+.mainsection-btn:hover {
+  text-decoration: none !important;
+  color: #000 !important;
+}


### PR DESCRIPTION
## Summary
- adjust overlay button styling so text stays white and gains black on hover
- add custom CSS class for main section button to disable underline

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@shopify/oxygen-workers-types')*

------
https://chatgpt.com/codex/tasks/task_e_6882b17814108326ab680bc7004d4166