### PR TITLE
Improve page load by lazily loading images

### DIFF
--- a/app/routes/($locale)._index.tsx
+++ b/app/routes/($locale)._index.tsx
@@ -188,6 +188,7 @@ function GridShowcase() {
           <img
             src={category.image}
             alt={category.title}
+            loading="lazy"
             className="w-full h-full object-cover transform transition-transform duration-500 group-hover:scale-105"
           />
           <div className="absolute bottom-4 left-4 text-white drop-shadow-lg">
@@ -238,6 +239,7 @@ function CategoryShowcase() {
           <img
             src="https://cdn.shopify.com/s/files/1/0704/7908/5731/files/bluedress.webp?v=1753221040"
             alt="Women"
+            loading="lazy"
             className="w-full aspect-[3/4] object-cover mb-4 rounded-xl"
           />
           <div>
@@ -253,6 +255,7 @@ function CategoryShowcase() {
           <img
             src="https://cdn.shopify.com/s/files/1/0704/7908/5731/files/white_dress.png?v=1753222198"
             alt="Men"
+            loading="lazy"
             className="w-full aspect-[3/4] object-cover mb-4 rounded-xl"
           />
           <div>


### PR DESCRIPTION
## Summary
- lazily load images in the grid and category sections

## Testing
- `npm install` *(fails: unable to reach registry)*
- `npm run lint` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6882c29f992883269c3efc04c5310322