### PR TITLE
Add margin to Heritage Grace block

### DIFF
--- a/app/routes/($locale)._index.tsx
+++ b/app/routes/($locale)._index.tsx
@@ -291,7 +291,7 @@ function CategoryShowcase() {
             whileHover={{scale:1.05}}
             transition={{duration:0.3}}
           />
-          <div>
+          <div className="ml-4">
             <h3 className="text-xl font-semibold uppercase mb-2 text-gray-900 tracking-wider font-['Playfair_Display'] text-[#d4af37]">
               Heritage Grace
             </h3>


### PR DESCRIPTION
## Summary
- tweak womenswear block spacing by adding `ml-4` class

## Testing
- `npm ci` *(fails: internet disabled)*
- `npm run lint` *(fails: cannot find @eslint/compat)*

------
https://chatgpt.com/codex/tasks/task_e_68830f53dd4c8326be3b3cb625b3d02c