### PR TITLE
Add left padding to Heritage Grace card

### DIFF
--- a/app/routes/($locale)._index.tsx
+++ b/app/routes/($locale)._index.tsx
@@ -282,7 +282,7 @@ function CategoryShowcase() {
       className={`w-full m-0 py-0 bg-white ${isVisible ? 'animate-fade-in-up' : 'opacity-0'}`}
     >
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
-        <div className="w-full">
+        <div className="w-full pl-4">
           <motion.img
             src="https://cdn.shopify.com/s/files/1/0704/7908/5731/files/bluedress.webp?v=1753221040"
             alt="Women"


### PR DESCRIPTION
## Summary
- add left padding so the Heritage Grace block no longer touches the page edge

## Testing
- `npm install --silent` *(fails: internet is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68831091a19c832684e66ec5cc9190c2