### PR TITLE
Fix section padding override

### DIFF
--- a/app/styles/reset.css
+++ b/app/styles/reset.css
@@ -70,15 +70,6 @@ pre {
   white-space: pre-wrap;
 }
 
-section {
-  padding: 0;
-}
-
-@media (min-width: 768px) {
-  section {
-    padding: 0;
-  }
-}
 
 fieldset {
   display: flex;


### PR DESCRIPTION
## Summary
- remove padding reset on `<section>` elements so page sections can define their own spacing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@shopify/oxygen-workers-types')*

------
https://chatgpt.com/codex/tasks/task_e_68832b58bae483269fc092a296f0c867