### PR TITLE
Improve collection page styling

### DIFF
--- a/app/routes/($locale).collections.$handle.tsx
+++ b/app/routes/($locale).collections.$handle.tsx
@@ -66,34 +66,26 @@ export default function Collection() {
   });
 
   return (
-    <section className="collection-page w-full">
+    <section className="collection-page w-full font-['Playfair_Display'] bg-gradient-to-b from-[#fefefe] to-[#f8f8f5]">
       {/* Hero Section */}
-      <div className="relative h-[25vh] flex flex-col items-center justify-center bg-[#1a1a1a] text-center px-4">
-        <h1
-          className="text-5xl md:text-7xl font-bold drop-shadow-xl"
-          style={{
-            color: '#d4af37',
-            fontSize: '3rem',
-            fontFamily: "'Great Vibes', cursive",
-            lineHeight: 1.1,
-          }}
-        >
+      <div className="relative h-[25vh] flex flex-col items-center justify-center bg-gradient-to-b from-[#e7d8c7] to-[#f8e8e4] text-center px-4">
+        <h1 className="text-5xl md:text-7xl font-['Cinzel'] dark-gold-gradient-text drop-shadow-lg">
           {collection.title}
         </h1>
       </div>
 
       {/* Filter and Sort Section */}
-      <div className="bg-white py-6 border-b border-gray-200">
+      <div className="bg-gradient-to-b from-[#fefefe] to-[#f8f8f5] py-6 border-b border-[#d9c5b2]">
         <div className="container mx-auto px-4 flex flex-wrap items-center justify-between gap-4">
           <div className="flex gap-2 flex-wrap">
             {['All', 'New Arrivals', 'Sale'].map((filter) => (
               <button
                 key={filter}
                 onClick={() => setActiveFilter(filter)}
-                className={`px-4 py-2 rounded-md border transition ${
+                className={`px-4 py-2 rounded-full border transition font-medium ${
                   activeFilter === filter
-                    ? 'bg-gray-900 text-white border-gray-900'
-                    : 'bg-gray-100 text-black hover:bg-gray-200 border-transparent'
+                    ? 'bg-gradient-to-r from-[#d4af37] via-[#f5e18a] to-[#d4af37] text-white border-transparent'
+                    : 'bg-white/80 text-gray-800 hover:bg-white border border-[#d9c5b2]'
                 }`}
               >
                 {filter}
@@ -102,7 +94,7 @@ export default function Collection() {
           </div>
           <div>
             <select
-              className="border border-gray-300 rounded px-3 py-2 text-black"
+              className="border border-[#d9c5b2] rounded px-3 py-2 text-gray-800 bg-white/80"
               value={sortOption}
               onChange={(e) => setSortOption(e.target.value)}
             >

--- a/app/routes/($locale).collections.all.tsx
+++ b/app/routes/($locale).collections.all.tsx
@@ -70,32 +70,24 @@ export default function Collection() {
   const connection = {...products, nodes: filteredNodes};
 
   return (
-    <section className="collection-page w-full">
-      <div className="relative h-[25vh] flex flex-col items-center justify-center bg-[#1a1a1a] text-center px-4">
-        <h1
-          className="text-5xl md:text-7xl font-bold drop-shadow-xl"
-          style={{
-            color: '#d4af37',
-            fontSize: '3rem',
-            fontFamily: "'Great Vibes', cursive",
-            lineHeight: 1.1,
-          }}
-        >
+    <section className="collection-page w-full font-['Playfair_Display'] bg-gradient-to-b from-[#fefefe] to-[#f8f8f5]">
+      <div className="relative h-[25vh] flex flex-col items-center justify-center bg-gradient-to-b from-[#e7d8c7] to-[#f8e8e4] text-center px-4">
+        <h1 className="text-5xl md:text-7xl font-['Cinzel'] dark-gold-gradient-text drop-shadow-lg">
           All Products
         </h1>
       </div>
 
-      <div className="bg-white py-6 border-b border-gray-200">
+      <div className="bg-gradient-to-b from-[#fefefe] to-[#f8f8f5] py-6 border-b border-[#d9c5b2]">
         <div className="container mx-auto px-4 flex flex-wrap items-center justify-between gap-4">
           <div className="flex gap-2 flex-wrap">
             {['All', 'New Arrivals', 'Sale'].map((filter) => (
               <button
                 key={filter}
                 onClick={() => setActiveFilter(filter)}
-                className={`px-4 py-2 rounded-md border transition ${
+                className={`px-4 py-2 rounded-full border transition font-medium ${
                   activeFilter === filter
-                    ? 'bg-gray-900 text-white border-gray-900'
-                    : 'bg-gray-100 text-black hover:bg-gray-200 border-transparent'
+                    ? 'bg-gradient-to-r from-[#d4af37] via-[#f5e18a] to-[#d4af37] text-white border-transparent'
+                    : 'bg-white/80 text-gray-800 hover:bg-white border border-[#d9c5b2]'
                 }`}
               >
                 {filter}
@@ -104,7 +96,7 @@ export default function Collection() {
           </div>
           <div>
             <select
-              className="border border-gray-300 rounded px-3 py-2 text-black"
+              className="border border-[#d9c5b2] rounded px-3 py-2 text-gray-800 bg-white/80"
               value={sortOption}
               onChange={(e) => setSortOption(e.target.value)}
             >

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -49,6 +49,12 @@
     color: transparent;
   }
 
+  .dark-gold-gradient-text {
+    background-image: linear-gradient(to bottom, #b9925e, #d2b174);
+    -webkit-background-clip: text;
+    color: transparent;
+  }
+
   .quote-mark::before {
     content: '“';
     position: absolute;


### PR DESCRIPTION
## Summary
- apply luxe gold gradients and fonts to collection and all-products pages
- switch hero header to darker gold text for a richer look

## Testing
- `npm run lint` *(fails: cannot find `@eslint/compat`)*
- `npm run typecheck` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_6883496f486483268144072a3a403dcc