### PR TITLE
Fix CSS syntax in tailwind utilities

### DIFF
--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -52,12 +52,12 @@
 
   .dark-brown-text {
     color: #4b3621;
+  }
 
   .dark-gold-gradient-text {
     background-image: linear-gradient(to bottom, #b9925e, #d2b174);
     -webkit-background-clip: text;
     color: transparent;
-
   }
 
   .quote-mark::before {


### PR DESCRIPTION
## Summary
- close missing CSS block and fix utilities

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@shopify/oxygen-workers-types')*

------
https://chatgpt.com/codex/tasks/task_e_68834f7c0c108326b2d3469e6e64d59d