### PR TITLE
Fix header contact link

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -268,12 +268,17 @@ export function HeaderMenu({
       {menu?.items.map((item) => {
         if (!item.url) return null;
 
-        const url =
+        let url =
           item.url.includes('myshopify.com') ||
           item.url.includes(publicStoreDomain) ||
           item.url.includes(primaryDomainUrl)
             ? new URL(item.url).pathname
             : item.url;
+
+        // Rewrite the Shopify contact page to the custom contact route
+        if (/\/pages\/contact\/?$/.test(url)) {
+          url = url.replace(/\/pages\/contact\/?$/, '/contact');
+        }
 
         return (
           <NavLink

--- a/app/routes/($locale).pages.$handle.tsx
+++ b/app/routes/($locale).pages.$handle.tsx
@@ -1,4 +1,4 @@
-import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
+import {redirect, type LoaderFunctionArgs} from '@shopify/remix-oxygen';
 import {useLoaderData, type MetaFunction} from 'react-router';
 import {redirectIfHandleIsLocalized} from '~/lib/redirect';
 
@@ -7,6 +7,11 @@ export const meta: MetaFunction<typeof loader> = ({data}) => {
 };
 
 export async function loader(args: LoaderFunctionArgs) {
+  const {params} = args;
+  if (params.handle && params.handle.toLowerCase() === 'contact') {
+    const prefix = params.locale ? `/${params.locale}` : '';
+    throw redirect(`${prefix}/contact`);
+  }
   // Start fetching non-critical data without blocking time to first byte
   const deferredData = loadDeferredData(args);
 


### PR DESCRIPTION
## Summary
- link menu's contact item to the custom contact page
- redirect old `/pages/contact` route to the new contact page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@shopify/oxygen-workers-types')*

------
https://chatgpt.com/codex/tasks/task_e_6883aabd48ac8326a8a6f51f16e21ac6