### PR TITLE
Center footer blocks and enhance quote styling

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -21,7 +21,7 @@ export function Footer({
           return (
             <footer className="footer">
               <div className="footer-inner">
-                <div className="footer-col">
+                <div className="footer-col footer-quote-block">
                   {logoUrl && (
                     <img src={logoUrl} alt={header.shop.name} className="footer-logo" />
                   )}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -248,13 +248,19 @@ button.reset:hover:not(:has(> *)) {
   margin: 0 auto;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 2rem;
+  gap: 3rem;
 }
 
 .footer-col {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  align-items: center;
+  text-align: center;
+}
+
+.footer-quote-block {
+  justify-content: center;
 }
 
 .footer-col h3 {
@@ -294,6 +300,7 @@ button.reset:hover:not(:has(> *)) {
 .footer-description {
   margin-bottom: 1rem;
   font-size: 0.95rem;
+  font-family: 'Brush Script MT', cursive;
 }
 
 .footer-bottom {


### PR DESCRIPTION
## Summary
- adjust footer grid gap for better spacing
- center content within each footer block
- vertically center the quote block and use a calligraphic font

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/compat')*
- `npm run typecheck` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68888c45a51083268f2164876a602449