### PR TITLE
Fix brand title color on home page

### DIFF
--- a/app/routes/($locale)._index.tsx
+++ b/app/routes/($locale)._index.tsx
@@ -292,7 +292,7 @@ function BrandStatement() {
       }`}
     >
       <div className="text-center max-w-6xl px-4">
-        <h1 className="text-[11rem] sm:text-[14rem] font-['Cinzel'] gold-gradient-text mb-10 leading-none">
+        <h1 className="text-[11rem] sm:text-[14rem] font-['Cinzel'] dark-brown-text mb-10 leading-none">
           WK WEARS
         </h1>
         <h2 className="text-[5rem] sm:text-[6rem] font-['Alex_Brush'] text-[#bfae80] mb-10">


### PR DESCRIPTION
## Summary
- use `dark-brown-text` class for the `WK WEARS` title to match product pages

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/compat')*
- `npm run typecheck` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_688a1439fd6c83269b36a960fd0a5a42