### PR TITLE
Fix cart item image layout

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -327,12 +327,15 @@ button.reset:hover:not(:has(> *)) {
 
 .cart-line {
   display: flex;
+  align-items: center;
   padding: 0.75rem 0;
 }
 
 .cart-line img {
-  height: 100%;
+  width: 80px;
+  height: 80px;
   display: block;
+  object-fit: cover;
   margin-right: 0.75rem;
 }
 


### PR DESCRIPTION
## Summary
- align images in cart items
- size and crop cart item images for better display

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@shopify/oxygen-workers-types')*

------
https://chatgpt.com/codex/tasks/task_e_688a20ce77a0832680ae926d55d556ce