### PR TITLE
Add image gallery to cart items

### DIFF
--- a/app/components/CartLineItem.tsx
+++ b/app/components/CartLineItem.tsx
@@ -1,6 +1,7 @@
 import type {CartLineUpdateInput} from '@shopify/hydrogen/storefront-api-types';
 import type {CartLayout} from '~/components/CartMain';
 import {CartForm, Image, type OptimisticCartLine} from '@shopify/hydrogen';
+import {useState} from 'react';
 import {useVariantUrl} from '~/lib/variants';
 import {Link} from 'react-router';
 import {ProductPrice} from './ProductPrice';
@@ -21,24 +22,41 @@ export function CartLineItem({
   line: CartLine;
 }) {
   const {id, merchandise} = line;
-  const {product, title, image, selectedOptions} = merchandise;
+  const {product, title, image: variantImage, selectedOptions} = merchandise;
   const lineItemUrl = useVariantUrl(product.handle, selectedOptions);
   const {close} = useAside();
 
+  let gallery = product.images?.nodes ?? [];
+  if (!gallery.length && variantImage) {
+    gallery = [{url: variantImage.url, altText: variantImage.altText}];
+  }
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const mainImage = gallery[selectedIndex];
+
   return (
     <li key={id} className="cart-line">
-      {image && (
-        <Image
-          alt={title}
-          aspectRatio="1/1"
-          data={image}
-          height={100}
-          loading="lazy"
-          width={100}
-        />
-      )}
+      <div className="cart-line-gallery">
+        {mainImage && (
+          <Image
+            data={mainImage}
+            className="gallery-main-image"
+            loading="lazy"
+          />
+        )}
+        <div className="gallery-thumbnails">
+          {gallery.map((img, idx) => (
+            <button
+              key={img.url}
+              className={`gallery-thumbnail ${idx === selectedIndex ? 'active' : ''}`}
+              onClick={() => setSelectedIndex(idx)}
+            >
+              <Image data={img} width={60} height={60} loading="lazy" />
+            </button>
+          ))}
+        </div>
+      </div>
 
-      <div>
+      <div className="cart-line-details">
         <Link
           prefetch="intent"
           to={lineItemUrl}

--- a/app/lib/fragments.ts
+++ b/app/lib/fragments.ts
@@ -47,6 +47,12 @@ export const CART_QUERY_FRAGMENT = `#graphql
           title
           id
           vendor
+          images(first: 5) {
+            nodes {
+              url
+              altText
+            }
+          }
         }
         selectedOptions {
           name
@@ -97,6 +103,12 @@ export const CART_QUERY_FRAGMENT = `#graphql
           title
           id
           vendor
+          images(first: 5) {
+            nodes {
+              url
+              altText
+            }
+          }
         }
         selectedOptions {
           name

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -16,6 +16,7 @@ import {FOOTER_QUERY, HEADER_QUERY} from '~/lib/fragments';
 import resetStyles from '~/styles/reset.css?url';
 import appStyles from '~/styles/app.css?url';
 import tailwindCss from './styles/tailwind.css?url';
+import '~/styles/cart.css';
 import {PageLayout} from './components/PageLayout';
 
 export type RootLoader = typeof loader;

--- a/app/styles/cart.css
+++ b/app/styles/cart.css
@@ -1,0 +1,67 @@
+/* 4.1 Two-column grid for cart details */
+.cart-details {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 4rem;
+}
+@media (max-width: 768px) {
+  .cart-details {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* 4.2 Each line item as grid */
+.cart-line {
+  display: grid;
+  grid-template-columns: minmax(200px,1fr) 1fr;
+  gap: 2rem;
+  padding: 1.5rem 0;
+  border-bottom: 1px solid #eee;
+}
+
+/* 4.3 Gallery styles */
+.cart-line-gallery {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.gallery-main-image {
+  width: 100%;
+  max-width: 300px;
+  aspect-ratio: 1/1;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+}
+.gallery-thumbnails {
+  display: flex;
+  gap: 0.5rem;
+}
+.gallery-thumbnail {
+  border: 2px solid transparent;
+  padding: 0;
+  background: none;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.gallery-thumbnail.active {
+  border-color: #000;
+}
+.gallery-thumbnail img {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
+/* 4.4 Details & quantity layout */
+.cart-line-details {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+.cart-line-quantity {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}

--- a/storefrontapi.generated.d.ts
+++ b/storefrontapi.generated.d.ts
@@ -31,7 +31,9 @@ export type CartLineFragment = Pick<
     image?: StorefrontAPI.Maybe<
       Pick<StorefrontAPI.Image, 'id' | 'url' | 'altText' | 'width' | 'height'>
     >;
-    product: Pick<StorefrontAPI.Product, 'handle' | 'title' | 'id' | 'vendor'>;
+    product: Pick<StorefrontAPI.Product, 'handle' | 'title' | 'id' | 'vendor'> & {
+      images: { nodes: Array<Pick<StorefrontAPI.Image, 'url' | 'altText'>> };
+    };
     selectedOptions: Array<
       Pick<StorefrontAPI.SelectedOption, 'name' | 'value'>
     >;
@@ -61,7 +63,9 @@ export type CartLineComponentFragment = Pick<
     image?: StorefrontAPI.Maybe<
       Pick<StorefrontAPI.Image, 'id' | 'url' | 'altText' | 'width' | 'height'>
     >;
-    product: Pick<StorefrontAPI.Product, 'handle' | 'title' | 'id' | 'vendor'>;
+    product: Pick<StorefrontAPI.Product, 'handle' | 'title' | 'id' | 'vendor'> & {
+      images: { nodes: Array<Pick<StorefrontAPI.Image, 'url' | 'altText'>> };
+    };
     selectedOptions: Array<
       Pick<StorefrontAPI.SelectedOption, 'name' | 'value'>
     >;
@@ -119,7 +123,9 @@ export type CartApiQueryFragment = Pick<
             product: Pick<
               StorefrontAPI.Product,
               'handle' | 'title' | 'id' | 'vendor'
-            >;
+            > & {
+              images: { nodes: Array<Pick<StorefrontAPI.Image, 'url' | 'altText'>> };
+            };
             selectedOptions: Array<
               Pick<StorefrontAPI.SelectedOption, 'name' | 'value'>
             >;
@@ -154,7 +160,9 @@ export type CartApiQueryFragment = Pick<
             product: Pick<
               StorefrontAPI.Product,
               'handle' | 'title' | 'id' | 'vendor'
-            >;
+            > & {
+              images: { nodes: Array<Pick<StorefrontAPI.Image, 'url' | 'altText'>> };
+            };
             selectedOptions: Array<
               Pick<StorefrontAPI.SelectedOption, 'name' | 'value'>
             >;


### PR DESCRIPTION
## Summary
- expand cart fragments to include product images
- render a thumbnail image gallery for cart items
- load new cart styles globally

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@shopify/oxygen-workers-types')*

------
https://chatgpt.com/codex/tasks/task_e_688a25a2eab88326a41269ad6529a110