### PR TITLE
Fix product image gallery

### DIFF
--- a/app/components/ProductGallery.tsx
+++ b/app/components/ProductGallery.tsx
@@ -1,0 +1,47 @@
+import {Image} from '@shopify/hydrogen';
+import {useState} from 'react';
+import type {ProductVariantFragment, ProductFragment} from 'storefrontapi.generated';
+
+export function ProductGallery({
+  images,
+  selectedVariantImage,
+}: {
+  images: Array<{url: string; altText?: string | null}>;
+  selectedVariantImage?: ProductVariantFragment['image'];
+}) {
+  let gallery = images || [];
+
+  // include variant image first if not already present
+  if (selectedVariantImage) {
+    const variantEntry = {url: selectedVariantImage.url, altText: selectedVariantImage.altText};
+    if (!gallery.find((img) => img.url === selectedVariantImage.url)) {
+      gallery = [variantEntry, ...gallery];
+    } else {
+      // ensure variant image is first
+      gallery = [variantEntry, ...gallery.filter((img) => img.url !== selectedVariantImage.url)];
+    }
+  }
+
+  const [index, setIndex] = useState(0);
+  const mainImage = gallery[index];
+
+  return (
+    <div className="product-gallery">
+      {mainImage && (
+        <Image data={mainImage} className="gallery-main-image" loading="eager" />
+      )}
+      <div className="gallery-thumbnails">
+        {gallery.map((img, idx) => (
+          <button
+            key={img.url}
+            type="button"
+            className={`gallery-thumbnail ${idx === index ? 'active' : ''}`}
+            onClick={() => setIndex(idx)}
+          >
+            <Image data={img} width={60} height={60} loading="lazy" />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -9,7 +9,7 @@ import {
   useSelectedOptionInUrlParam,
 } from '@shopify/hydrogen';
 import {ProductPrice} from '~/components/ProductPrice';
-import {ProductImage} from '~/components/ProductImage';
+import {ProductGallery} from '~/components/ProductGallery';
 import {ProductForm} from '~/components/ProductForm';
 import {redirectIfHandleIsLocalized} from '~/lib/redirect';
 
@@ -103,7 +103,10 @@ export default function Product() {
 
   return (
     <div className="product">
-      <ProductImage image={selectedVariant?.image} />
+      <ProductGallery
+        images={product.images?.nodes || []}
+        selectedVariantImage={selectedVariant?.image}
+      />
       <div className="product-main">
         <h1>{title}</h1>
         <ProductPrice
@@ -190,6 +193,12 @@ const PRODUCT_FRAGMENT = `#graphql
     description
     encodedVariantExistence
     encodedVariantAvailability
+    images(first: 10) {
+      nodes {
+        url
+        altText
+      }
+    }
     options {
       name
       optionValues {

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -516,6 +516,44 @@ button.reset:hover:not(:has(> *)) {
   width: 100%;
 }
 
+.product-gallery {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.gallery-main-image {
+  width: 100%;
+  max-width: 600px;
+  aspect-ratio: 1/1;
+  object-fit: cover;
+  margin-bottom: 0.75rem;
+}
+
+.gallery-thumbnails {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.gallery-thumbnail {
+  border: 2px solid transparent;
+  padding: 0;
+  background: none;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.gallery-thumbnail.active {
+  border-color: #000;
+}
+
+.gallery-thumbnail img {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
 .product-main {
   align-self: start;
   position: sticky;

--- a/storefrontapi.generated.d.ts
+++ b/storefrontapi.generated.d.ts
@@ -699,6 +699,7 @@ export type ProductFragment = Pick<
   | 'encodedVariantExistence'
   | 'encodedVariantAvailability'
 > & {
+  images: {nodes: Array<Pick<StorefrontAPI.Image, 'url' | 'altText'>>};
   options: Array<
     Pick<StorefrontAPI.ProductOption, 'name'> & {
       optionValues: Array<
@@ -813,6 +814,7 @@ export type ProductQuery = {
       | 'encodedVariantExistence'
       | 'encodedVariantAvailability'
     > & {
+      images: {nodes: Array<Pick<StorefrontAPI.Image, 'url' | 'altText'>>};
       options: Array<
         Pick<StorefrontAPI.ProductOption, 'name'> & {
           optionValues: Array<


### PR DESCRIPTION
## Summary
- allow multiple product images by adding a gallery
- fetch product image data in the product page query
- style the product gallery
- update types for the new images field

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*
- `npm run typecheck` *(fails: Cannot find type definition file for '@shopify/oxygen-workers-types')*

------
https://chatgpt.com/codex/tasks/task_e_688a33f32af483269b22805e8e500ab9