### PR TITLE
Add product image lightbox

### DIFF
--- a/app/components/ProductGallery.tsx
+++ b/app/components/ProductGallery.tsx
@@ -1,5 +1,5 @@
 import {Image} from '@shopify/hydrogen';
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import type {ProductVariantFragment, ProductFragment} from 'storefrontapi.generated';
 
 export function ProductGallery({
@@ -23,12 +23,56 @@ export function ProductGallery({
   }
 
   const [index, setIndex] = useState(0);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
   const mainImage = gallery[index];
+
+  useEffect(() => {
+    const first = gallery[0];
+    if (!first) return;
+    const link = document.createElement('link');
+    link.rel = 'preload';
+    link.as = 'image';
+    link.href = first.url;
+    document.head.appendChild(link);
+    return () => {
+      document.head.removeChild(link);
+    };
+  }, [gallery]);
+
+  useEffect(() => {
+    if (!lightboxOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') {
+        setIndex((i) => (i - 1 + gallery.length) % gallery.length);
+      } else if (e.key === 'ArrowRight') {
+        setIndex((i) => (i + 1) % gallery.length);
+      } else if (e.key === 'Escape') {
+        setLightboxOpen(false);
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', handleKey);
+      document.body.style.overflow = '';
+    };
+  }, [lightboxOpen, gallery.length]);
 
   return (
     <div className="product-gallery">
       {mainImage && (
-        <Image data={mainImage} className="gallery-main-image" loading="eager" />
+        <Image
+          data={mainImage}
+          className="gallery-main-image"
+          loading="eager"
+          width={800}
+          height={800}
+          sizes="(min-width: 1024px) 600px, (min-width: 640px) 60vw, 100vw"
+          loaderOptions={{format: 'webp'}}
+          fetchpriority="high"
+          onClick={() => setLightboxOpen(true)}
+          style={{cursor: 'zoom-in'}}
+        />
       )}
       <div className="gallery-thumbnails">
         {gallery.map((img, idx) => (
@@ -42,6 +86,34 @@ export function ProductGallery({
           </button>
         ))}
       </div>
+      {lightboxOpen && (
+        <div className="lightbox-overlay" onClick={() => setLightboxOpen(false)}>
+          <button
+            className="lightbox-prev"
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIndex((i) => (i - 1 + gallery.length) % gallery.length);
+            }}
+          >
+            &#10094;
+          </button>
+          <img
+            src={gallery[index].url}
+            alt={gallery[index].altText || ''}
+          />
+          <button
+            className="lightbox-next"
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setIndex((i) => (i + 1) % gallery.length);
+            }}
+          >
+            &#10095;
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -647,3 +647,45 @@ button.reset:hover:not(:has(> *)) {
 .mainsection-btn:hover {
   text-decoration: none !important;
 }
+
+/*
+ * --------------------------------------------------
+ * Lightbox styles
+ * --------------------------------------------------
+ */
+.lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.9);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.lightbox-overlay img {
+  max-width: 90%;
+  max-height: 90%;
+  object-fit: contain;
+}
+
+.lightbox-prev,
+.lightbox-next {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  cursor: pointer;
+  padding: 0 1rem;
+}
+
+.lightbox-prev {
+  left: 0.5rem;
+}
+
+.lightbox-next {
+  right: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- enhance ProductGallery with lightbox overlay
- preload first product image to improve LCP
- provide responsive image sizes and high fetch priority
- style lightbox for full-screen zoom

## Testing
- `npm run lint` *(fails: cannot find package)*
- `npm install` *(fails due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_688a37b7e8b48326948260897bdfb440