### PR TITLE
Add animations to product pages

### DIFF
--- a/app/components/AddToCartButton.tsx
+++ b/app/components/AddToCartButton.tsx
@@ -1,5 +1,6 @@
 import {type FetcherWithComponents} from 'react-router';
 import {CartForm, type OptimisticCartLineInput} from '@shopify/hydrogen';
+import {motion} from 'framer-motion';
 
 export function AddToCartButton({
   analytics,
@@ -7,12 +8,14 @@ export function AddToCartButton({
   disabled,
   lines,
   onClick,
+  className,
 }: {
   analytics?: unknown;
   children: React.ReactNode;
   disabled?: boolean;
   lines: Array<OptimisticCartLineInput>;
   onClick?: () => void;
+  className?: string;
 }) {
   return (
     <CartForm route="/cart" inputs={{lines}} action={CartForm.ACTIONS.LinesAdd}>
@@ -23,13 +26,17 @@ export function AddToCartButton({
             type="hidden"
             value={JSON.stringify(analytics)}
           />
-          <button
+          <motion.button
             type="submit"
             onClick={onClick}
             disabled={disabled ?? fetcher.state !== 'idle'}
+            className={className}
+            whileHover={{scale: 1.05}}
+            whileTap={{scale: 0.95}}
+            transition={{type: 'spring', stiffness: 300}}
           >
             {children}
-          </button>
+          </motion.button>
         </>
       )}
     </CartForm>

--- a/app/components/ProductForm.tsx
+++ b/app/components/ProductForm.tsx
@@ -106,6 +106,7 @@ export function ProductForm({
         onClick={() => {
           open('cart');
         }}
+        className="w-full mt-4 bg-gradient-to-r from-[#d4af37] via-[#f5e18a] to-[#d4af37] text-white font-semibold py-3 rounded-lg shadow-lg"
         lines={
           selectedVariant
             ? [

--- a/app/components/ProductGallery.tsx
+++ b/app/components/ProductGallery.tsx
@@ -1,5 +1,6 @@
 import {Image} from '@shopify/hydrogen';
 import {useEffect, useState} from 'react';
+import {motion, AnimatePresence} from 'framer-motion';
 import type {ProductVariantFragment, ProductFragment} from 'storefrontapi.generated';
 
 export function ProductGallery({
@@ -61,18 +62,29 @@ export function ProductGallery({
   return (
     <div className="product-gallery">
       {mainImage && (
-        <Image
-          data={mainImage}
-          className="gallery-main-image"
-          loading="eager"
-          width={800}
-          height={800}
-          sizes="(min-width: 1024px) 600px, (min-width: 640px) 60vw, 100vw"
-          loaderOptions={{format: 'webp'}}
-          fetchpriority="high"
-          onClick={() => setLightboxOpen(true)}
-          style={{cursor: 'zoom-in'}}
-        />
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={mainImage.url}
+            initial={{opacity: 0}}
+            animate={{opacity: 1}}
+            exit={{opacity: 0}}
+            transition={{duration: 0.3}}
+            className="w-full"
+          >
+            <Image
+              data={mainImage}
+              className="gallery-main-image"
+              loading="eager"
+              width={800}
+              height={800}
+              sizes="(min-width: 1024px) 600px, (min-width: 640px) 60vw, 100vw"
+              loaderOptions={{format: 'webp'}}
+              fetchpriority="high"
+              onClick={() => setLightboxOpen(true)}
+              style={{cursor: 'zoom-in'}}
+            />
+          </motion.div>
+        </AnimatePresence>
       )}
       <div className="gallery-thumbnails">
         {gallery.map((img, idx) => (

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -8,6 +8,7 @@ import {
   getAdjacentAndFirstAvailableVariants,
   useSelectedOptionInUrlParam,
 } from '@shopify/hydrogen';
+import {motion} from 'framer-motion';
 import {ProductPrice} from '~/components/ProductPrice';
 import {ProductGallery} from '~/components/ProductGallery';
 import {ProductForm} from '~/components/ProductForm';
@@ -102,7 +103,11 @@ export default function Product() {
   const {title, descriptionHtml} = product;
 
   return (
-    <div className="product">
+    <motion.div
+      className="product px-4 py-8 bg-gradient-to-b from-white to-[#f8f8f5] rounded-lg shadow-lg animate-fade-in-scale"
+      initial={{opacity: 0, y: 20}}
+      animate={{opacity: 1, y: 0}}
+    >
       <ProductGallery
         images={product.images?.nodes || []}
         selectedVariantImage={selectedVariant?.image}
@@ -142,7 +147,7 @@ export default function Product() {
           ],
         }}
       />
-    </div>
+    </motion.div>
   );
 }
 


### PR DESCRIPTION
## Summary
- animate AddToCartButton with framer motion and add styling support
- add gradient button styles in `ProductForm`
- fade image transitions in `ProductGallery`
- wrap product page with animated container

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*
- `npm run typecheck` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_688a39d5eaf083269f398ecbf5789199