### PR TITLE
Add breadcrumb snippet and styling

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -16,6 +16,7 @@ import {FOOTER_QUERY, HEADER_QUERY} from '~/lib/fragments';
 import resetStyles from '~/styles/reset.css?url';
 import appStyles from '~/styles/app.css?url';
 import tailwindCss from './styles/tailwind.css?url';
+import breadcrumbCss from './styles/breadcrumb.css?url';
 import '~/styles/cart.css';
 import {PageLayout} from './components/PageLayout';
 
@@ -169,6 +170,7 @@ export function Layout({children}: {children?: React.ReactNode}) {
         <link rel="stylesheet" href={tailwindCss}></link>
         <link rel="stylesheet" href={resetStyles}></link>
         <link rel="stylesheet" href={appStyles}></link>
+        <link rel="stylesheet" href={breadcrumbCss}></link>
         <Meta />
         <Links />
       </head>

--- a/app/styles/breadcrumb.css
+++ b/app/styles/breadcrumb.css
@@ -1,0 +1,19 @@
+.breadcrumb {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-family: 'Lato', sans-serif;
+  font-size: 14px;
+}
+
+.breadcrumb li + li::before {
+  content: '›';
+  color: #888;
+  margin: 0 0.5rem;
+}
+
+.breadcrumb a {
+  color: #888;
+  text-decoration: none;
+}

--- a/snippets/breadcrumb.liquid
+++ b/snippets/breadcrumb.liquid
@@ -1,0 +1,7 @@
+<nav aria-label="Breadcrumb">
+  <ul class="breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a href="/collections/womens-shirts">Women’s Shirts</a></li>
+    <li><span aria-current="page">Limelight Yarn‑Dyed Embroidered Shirt</span></li>
+  </ul>
+</nav>


### PR DESCRIPTION
## Summary
- add Liquid snippet for breadcrumb trail
- add breadcrumb CSS and import in root layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*
- `npm run typecheck` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688a3f8856e48326a845002da5917ab8