### PR TITLE
Add FAQ accordion snippet

### DIFF
--- a/snippets/faq-accordion.html
+++ b/snippets/faq-accordion.html
@@ -1,0 +1,37 @@
+<!-- Accessible FAQ Accordion -->
+<div class="faq-accordion">
+  <details>
+    <summary>Question 1?</summary>
+    <p>Answer to question 1.</p>
+  </details>
+  <details>
+    <summary>Question 2?</summary>
+    <p>Answer to question 2.</p>
+  </details>
+  <details>
+    <summary>Question 3?</summary>
+    <p>Answer to question 3.</p>
+  </details>
+  <details>
+    <summary>Question 4?</summary>
+    <p>Answer to question 4.</p>
+  </details>
+</div>
+
+<style>
+.faq-accordion summary {
+  font-family: 'Playfair Display', serif;
+  font-size: 20px;
+  color: #000;
+  cursor: pointer;
+}
+.faq-accordion p {
+  font-family: 'Lato', sans-serif;
+  font-size: 16px;
+  color: #333;
+  margin: 0 0 1rem 0;
+}
+.faq-accordion details + details {
+  margin-top: 1rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- add HTML snippet for accessible FAQ accordion using `<details>` and `<summary>` with Playfair Display 20px headings and Lato 16px answers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a444cd7ec832681f7bd6bd68a1f67