### PR TITLE
Add Swiper carousel snippet

### DIFF
--- a/snippets/related-products-carousel.html
+++ b/snippets/related-products-carousel.html
@@ -1,0 +1,56 @@
+<section class="related-products">
+  <h2 class="playfair text-2xl mb-4">You Might Also Like</h2>
+  <div class="swiper-container related-swiper">
+    <div class="swiper-wrapper">
+      <div class="swiper-slide">
+        <a href="#" class="block text-center">
+          <img src="/path/to/product1.jpg" alt="Product 1" class="w-full h-auto" />
+          <p class="mt-2 font-medium">Product 1</p>
+          <span class="text-sm">$99.99</span>
+        </a>
+      </div>
+      <div class="swiper-slide">
+        <a href="#" class="block text-center">
+          <img src="/path/to/product2.jpg" alt="Product 2" class="w-full h-auto" />
+          <p class="mt-2 font-medium">Product 2</p>
+          <span class="text-sm">$89.99</span>
+        </a>
+      </div>
+      <div class="swiper-slide">
+        <a href="#" class="block text-center">
+          <img src="/path/to/product3.jpg" alt="Product 3" class="w-full h-auto" />
+          <p class="mt-2 font-medium">Product 3</p>
+          <span class="text-sm">$79.99</span>
+        </a>
+      </div>
+    </div>
+    <div class="swiper-button-prev"></div>
+    <div class="swiper-button-next"></div>
+  </div>
+</section>
+
+<link rel="stylesheet" href="https://unpkg.com/swiper@11/swiper-bundle.min.css" />
+<script type="module">
+  import Swiper, {Navigation} from 'https://unpkg.com/swiper@11/swiper-bundle.esm.browser.min.js';
+
+  const swiper = new Swiper('.related-swiper', {
+    modules: [Navigation],
+    loop: true,
+    navigation: {
+      nextEl: '.swiper-button-next',
+      prevEl: '.swiper-button-prev',
+    },
+    slidesPerView: 1,
+    spaceBetween: 8,
+    breakpoints: {
+      640: {
+        slidesPerView: 2,
+        spaceBetween: 16,
+      },
+      1024: {
+        slidesPerView: 4,
+        spaceBetween: 24,
+      },
+    },
+  });
+</script>


### PR DESCRIPTION
## Summary
- add `related-products-carousel.html` snippet to demo Swiper carousel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a46e9110483269724b29d0d4457a6