### PR TITLE
Add size guide modal and product JSON-LD

### DIFF
--- a/app/components/SizeGuideModal.tsx
+++ b/app/components/SizeGuideModal.tsx
@@ -1,0 +1,105 @@
+import {useEffect, useRef} from 'react';
+
+export function SizeGuideModal() {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  // open dialog when clicking anchor link
+  useEffect(() => {
+    function handleClick(event: MouseEvent) {
+      const target = event.target as HTMLElement;
+      if (target && target.closest('a[href="#size-modal"]')) {
+        event.preventDefault();
+        dialogRef.current?.showModal();
+        const first = dialogRef.current?.querySelector<HTMLElement>('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        first?.focus();
+      }
+    }
+    document.addEventListener('click', handleClick);
+    return () => document.removeEventListener('click', handleClick);
+  }, []);
+
+  // focus trap inside dialog
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    function trap(event: KeyboardEvent) {
+      if (event.key !== 'Tab' || !dialog.open) return;
+      const elements = dialog.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      if (!elements.length) return;
+      const first = elements[0];
+      const last = elements[elements.length - 1];
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+    dialog.addEventListener('keydown', trap);
+    return () => dialog.removeEventListener('keydown', trap);
+  }, []);
+
+  return (
+    <dialog id="size-modal" ref={dialogRef} aria-labelledby="size-modal-title">
+      <button className="close" aria-label="Close" onClick={() => dialogRef.current?.close()}>
+        ✕
+      </button>
+      <h2 id="size-modal-title" className="font-['Playfair_Display'] text-[20px] mb-4">
+        Size Guide
+      </h2>
+      <table className="w-full text-left border-collapse">
+        <thead>
+          <tr>
+            <th>Size</th>
+            <th>Bust</th>
+            <th>Waist</th>
+            <th>Hip</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">XS</th>
+            <td>32"</td>
+            <td>24"</td>
+            <td>34"</td>
+          </tr>
+          <tr>
+            <th scope="row">S</th>
+            <td>34"</td>
+            <td>26"</td>
+            <td>36"</td>
+          </tr>
+          <tr>
+            <th scope="row">M</th>
+            <td>36"</td>
+            <td>28"</td>
+            <td>38"</td>
+          </tr>
+          <tr>
+            <th scope="row">L</th>
+            <td>38"</td>
+            <td>30"</td>
+            <td>40"</td>
+          </tr>
+          <tr>
+            <th scope="row">XL</th>
+            <td>40"</td>
+            <td>32"</td>
+            <td>42"</td>
+          </tr>
+          <tr>
+            <th scope="row">XXL</th>
+            <td>42"</td>
+            <td>34"</td>
+            <td>44"</td>
+          </tr>
+        </tbody>
+      </table>
+    </dialog>
+  );
+}

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -12,6 +12,7 @@ import {motion} from 'framer-motion';
 import {ProductPrice} from '~/components/ProductPrice';
 import {ProductGallery} from '~/components/ProductGallery';
 import {ProductForm} from '~/components/ProductForm';
+import {SizeGuideModal} from '~/components/SizeGuideModal';
 import {redirectIfHandleIsLocalized} from '~/lib/redirect';
 
 export const meta: MetaFunction<typeof loader> = ({data}) => {
@@ -123,6 +124,9 @@ export default function Product() {
           productOptions={productOptions}
           selectedVariant={selectedVariant}
         />
+        <p className="mt-2">
+          <a href="#size-modal" className="underline text-sm">View Size Guide</a>
+        </p>
         <br />
         <br />
         <p>
@@ -145,6 +149,14 @@ export default function Product() {
               quantity: 1,
             },
           ],
+        }}
+      />
+      <SizeGuideModal />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html:
+            '{"@context":"https://schema.org","@type":"Product","name":"Limelight Yarn-Dyed Embroidered Shirt","image":["url1.jpg","url2.jpg"],"description":"Elevate your look with handcrafted pearl-studded yarn-dyed cotton…","sku":"LIME123","brand":{"@type":"Brand","name":"Limelight"},"offers":{"@type":"Offer","price":"24.99","priceCurrency":"USD","availability":"https://schema.org/InStock"},"aggregateRating":{"@type":"AggregateRating","ratingValue":"4.8","reviewCount":"324"}}',
         }}
       />
     </motion.div>

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -689,3 +689,25 @@ button.reset:hover:not(:has(> *)) {
 .lightbox-next {
   right: 0.5rem;
 }
+#size-modal {
+  border: none;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  max-width: 500px;
+}
+#size-modal::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}
+#size-modal h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 20px;
+}
+#size-modal .close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add SizeGuideModal component with dialog and focus trap
- link to open modal from product page
- add JSON-LD Product schema for SEO
- style modal in app.css

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*
- `npm run typecheck` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688a4ad6ac388326bb9dbd29b2c62375