### PR TITLE
Adjust product page layout

### DIFF
--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -131,10 +131,8 @@ export default function Product() {
         <p className="mt-2">
           <a href="#size-modal" className="underline text-sm">View Size Guide</a>
         </p>
-        <details>
-          <summary className="text-lg font-bold">Description</summary>
-          <div className="mt-2" dangerouslySetInnerHTML={{__html: descriptionHtml}} />
-        </details>
+        <h2 className="text-lg font-bold">Description</h2>
+        <div className="mt-2" dangerouslySetInnerHTML={{__html: descriptionHtml}} />
         <details className="mt-4">
           <summary className="text-lg font-bold">Care Instructions</summary>
           <p className="mt-2 text-sm">Hand wash cold, lay flat to dry. Do not bleach.</p>

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -528,15 +528,13 @@ button.reset:hover:not(:has(> *)) {
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 100%;
-  max-width: 600px;
+  width: 500px;
   margin: 0 auto;
 }
 
 .gallery-main-image {
-  width: 100%;
-  max-width: 600px;
-  aspect-ratio: 1/1;
+  width: 500px;
+  height: 500px;
   object-fit: cover;
   margin-bottom: 0.75rem;
 }
@@ -574,6 +572,7 @@ button.reset:hover:not(:has(> *)) {
   flex-direction: column;
   gap: 1.25rem;
   text-align: center;
+  width: 65%;
 }
 
 .product-price-on-sale {


### PR DESCRIPTION
## Summary
- remove description accordion and show product text directly
- set product text block width to 65%
- constrain product image to fixed size on product page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 80 errors, 6 warnings)
- `npm run typecheck` (fails: TS2322, TS2305, TS18047, TS2307)


------
https://chatgpt.com/codex/tasks/task_e_688b37adff7083268f0fc93bc57d993f