### PR TITLE
feat: add sticky cart bar with size and quantity

### DIFF
--- a/app/components/ProductForm.tsx
+++ b/app/components/ProductForm.tsx
@@ -4,8 +4,6 @@ import type {
   Maybe,
   ProductOptionValueSwatch,
 } from '@shopify/hydrogen/storefront-api-types';
-import {AddToCartButton} from './AddToCartButton';
-import {useAside} from './Aside';
 import type {ProductFragment} from 'storefrontapi.generated';
 
 export function ProductForm({
@@ -16,7 +14,6 @@ export function ProductForm({
   selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
 }) {
   const navigate = useNavigate();
-  const {open} = useAside();
   return (
     <div className="product-form">
       {productOptions.map((option) => {
@@ -101,26 +98,6 @@ export function ProductForm({
           </div>
         );
       })}
-      <AddToCartButton
-        disabled={!selectedVariant || !selectedVariant.availableForSale}
-        onClick={() => {
-          open('cart');
-        }}
-        className="w-full mt-4 bg-gradient-to-r from-[#d4af37] via-[#f5e18a] to-[#d4af37] text-white font-semibold py-3 rounded-lg shadow-lg"
-        lines={
-          selectedVariant
-            ? [
-                {
-                  merchandiseId: selectedVariant.id,
-                  quantity: 1,
-                  selectedVariant,
-                },
-              ]
-            : []
-        }
-      >
-        {selectedVariant?.availableForSale ? 'Add to cart' : 'Sold out'}
-      </AddToCartButton>
     </div>
   );
 }

--- a/app/components/StickyCartBar.tsx
+++ b/app/components/StickyCartBar.tsx
@@ -1,0 +1,69 @@
+import {useState} from 'react';
+import type {ProductFragment} from 'storefrontapi.generated';
+import {AddToCartButton} from './AddToCartButton';
+import {useAside} from './Aside';
+
+export function StickyCartBar({
+  selectedVariant,
+}: {
+  selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
+}) {
+  const {open} = useAside();
+  const [quantity, setQuantity] = useState(0);
+  const [added, setAdded] = useState(false);
+
+  const size = selectedVariant?.selectedOptions?.find(
+    (o) => o.name.toLowerCase() === 'size',
+  )?.value;
+
+  const disabled =
+    !selectedVariant || quantity < 1 || !selectedVariant.availableForSale;
+  const buttonText = !selectedVariant ? 'Select size' : 'Add to cart';
+
+  function handleClick() {
+    setAdded(true);
+    open('cart');
+    setTimeout(() => setAdded(false), 800);
+  }
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 border-t bg-white p-2 flex items-center gap-4 text-sm">
+      <div className="flex items-center gap-4 flex-1">
+        <span>{size ? `Size: ${size}` : 'Size: -'}</span>
+        <div className="flex items-center border rounded">
+          <button
+            type="button"
+            className="px-2"
+            onClick={() => setQuantity(Math.max(0, quantity - 1))}
+          >
+            -
+          </button>
+          <span className="px-2 w-6 text-center">{quantity}</span>
+          <button type="button" className="px-2" onClick={() => setQuantity(quantity + 1)}>
+            +
+          </button>
+        </div>
+      </div>
+      <AddToCartButton
+        disabled={disabled}
+        onClick={handleClick}
+        className={`flex-1 py-2 rounded text-white transition-colors duration-300 ${
+          added ? 'bg-green-500' : 'bg-black'
+        }`}
+        lines={
+          selectedVariant
+            ? [
+                {
+                  merchandiseId: selectedVariant.id,
+                  quantity,
+                  selectedVariant,
+                },
+              ]
+            : []
+        }
+      >
+        {added ? '✓ Added' : buttonText}
+      </AddToCartButton>
+    </div>
+  );
+}

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -15,6 +15,7 @@ import {ProductForm} from '~/components/ProductForm';
 import {SizeGuideModal} from '~/components/SizeGuideModal';
 import {ReviewStars} from '~/components/ReviewStars';
 import {redirectIfHandleIsLocalized} from '~/lib/redirect';
+import {StickyCartBar} from '~/components/StickyCartBar';
 
 export const meta: MetaFunction<typeof loader> = ({data}) => {
   return [
@@ -121,12 +122,10 @@ export default function Product() {
           price={selectedVariant?.price}
           compareAtPrice={selectedVariant?.compareAtPrice}
         />
-        <div className="sticky-atc">
-          <ProductForm
-            productOptions={productOptions}
-            selectedVariant={selectedVariant}
-          />
-        </div>
+        <ProductForm
+          productOptions={productOptions}
+          selectedVariant={selectedVariant}
+        />
         <p className="mt-2">
           <a href="#size-modal" className="underline text-sm">View Size Guide</a>
         </p>
@@ -137,6 +136,7 @@ export default function Product() {
           <p className="mt-2 text-sm">Hand wash cold, lay flat to dry. Do not bleach.</p>
         </details>
       </div>
+      <StickyCartBar selectedVariant={selectedVariant} />
       <Analytics.ProductView
         data={{
           products: [

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -619,14 +619,6 @@ button.reset:hover:not(:has(> *)) {
   width: 100%;
 }
 
-.sticky-atc {
-  position: sticky;
-  bottom: 0;
-  background: #fff;
-  padding-top: 1rem;
-  padding-bottom: 1rem;
-}
-
 /*
 * --------------------------------------------------
 * routes/blog._index.tsx


### PR DESCRIPTION
## Summary
- introduce fixed cart bar with size and quantity controls
- animate add-to-cart with checkmark feedback
- remove unused sticky-atc styles

## Testing
- `npm run lint` *(fails: Visible, non-interactive elements with click handlers must have at least one keyboard listener)*
- `npx eslint app/components/StickyCartBar.tsx app/components/ProductForm.tsx app/routes/($locale).products.$handle.tsx`
- `npm run typecheck` *(fails: Cannot find module 'virtual:react-router/server-build')*

------
https://chatgpt.com/codex/tasks/task_e_688b3bb8c1b083269bb0ca4a0613aa29