### PR TITLE
Fix Add to Cart button visibility

### DIFF
--- a/app/components/StickyCartBar.tsx
+++ b/app/components/StickyCartBar.tsx
@@ -9,7 +9,7 @@ export function StickyCartBar({
   selectedVariant: ProductFragment['selectedOrFirstAvailableVariant'];
 }) {
   const {open} = useAside();
-  const [quantity, setQuantity] = useState(0);
+  const [quantity, setQuantity] = useState(1);
   const [added, setAdded] = useState(false);
 
   const size = selectedVariant?.selectedOptions?.find(


### PR DESCRIPTION
## Summary
- show the add to cart button immediately by starting quantity at one

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: "cy" is not defined)
- `npm run typecheck` (fails: TS2322, TS2305, TS18047, TS2307)


------
https://chatgpt.com/codex/tasks/task_e_688b3e3ebaa8832684f173999b37905b