### PR TITLE
Revamp product page layout and styling

### DIFF
--- a/app/components/StickyCartBar.tsx
+++ b/app/components/StickyCartBar.tsx
@@ -27,19 +27,19 @@ export function StickyCartBar({
   }
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-50 border-t bg-white p-2 flex items-center gap-4 text-sm">
+    <div className="fixed bottom-0 left-0 right-0 z-50 border-t bg-white p-4 flex items-center gap-4 text-base">
       <div className="flex items-center gap-4 flex-1">
         <span>{size ? `Size: ${size}` : 'Size: -'}</span>
         <div className="flex items-center border rounded">
           <button
             type="button"
-            className="px-2"
+            className="px-3"
             onClick={() => setQuantity(Math.max(0, quantity - 1))}
           >
             -
           </button>
-          <span className="px-2 w-6 text-center">{quantity}</span>
-          <button type="button" className="px-2" onClick={() => setQuantity(quantity + 1)}>
+          <span className="px-3 w-6 text-center">{quantity}</span>
+          <button type="button" className="px-3" onClick={() => setQuantity(quantity + 1)}>
             +
           </button>
         </div>
@@ -47,8 +47,8 @@ export function StickyCartBar({
       <AddToCartButton
         disabled={disabled}
         onClick={handleClick}
-        className={`flex-1 py-2 rounded text-white transition-colors duration-300 ${
-          added ? 'bg-green-500' : 'bg-black'
+        className={`flex-1 py-4 rounded-full text-white font-bold flex items-center justify-center gap-2 transition-colors duration-300 ${
+          added ? 'bg-green-600' : 'bg-orange-600 hover:bg-orange-700'
         }`}
         lines={
           selectedVariant
@@ -62,7 +62,7 @@ export function StickyCartBar({
             : []
         }
       >
-        {added ? '✓ Added' : buttonText}
+        {added ? '✓ Added' : (<><span role="img" aria-label="cart">🛒</span> Add to Cart</>)}
       </AddToCartButton>
     </div>
   );

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -76,7 +76,7 @@ export function links() {
     {
       rel: 'stylesheet',
       href:
-        'https://fonts.googleapis.com/css2?family=Alex+Brush&family=Cinzel:wght@400;700&family=Great+Vibes&family=Playfair+Display:wght@400;700&family=Roboto:wght@300;400;700&display=swap',
+        'https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Montserrat:wght@400;600;700&family=Poppins:wght@400;600;700&display=swap',
     },
     {rel: 'icon', type: 'image/svg+xml', href: favicon},
   ];

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -111,19 +111,19 @@ function StickyCartBar({
   }
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-50 border-t bg-white p-2 flex items-center gap-4 text-sm">
+    <div className="fixed bottom-0 left-0 right-0 z-50 border-t bg-white p-4 flex items-center gap-4 text-base">
       <div className="flex items-center gap-4 flex-1">
         <span>{size ? `Size: ${size}` : 'Size: -'}</span>
         <div className="flex items-center border rounded">
           <button
             type="button"
-            className="px-2"
+            className="px-3"
             onClick={() => setQuantity(Math.max(0, quantity - 1))}
           >
             -
           </button>
-          <span className="px-2 w-6 text-center">{quantity}</span>
-          <button type="button" className="px-2" onClick={() => setQuantity(quantity + 1)}>
+          <span className="px-3 w-6 text-center">{quantity}</span>
+          <button type="button" className="px-3" onClick={() => setQuantity(quantity + 1)}>
             +
           </button>
         </div>
@@ -131,8 +131,8 @@ function StickyCartBar({
       <AddToCartButton
         disabled={disabled}
         onClick={handleClick}
-        className={`flex-1 py-2 rounded text-white transition-colors duration-300 ${
-          added ? 'bg-green-500' : 'bg-black'
+        className={`flex-1 py-4 rounded-full text-white font-bold flex items-center justify-center gap-2 transition-colors duration-300 ${
+          added ? 'bg-green-600' : 'bg-orange-600 hover:bg-orange-700'
         }`}
         lines={
           selectedVariant
@@ -146,7 +146,7 @@ function StickyCartBar({
             : []
         }
       >
-        {added ? '✓ Added' : buttonText}
+        {added ? '✓ Added' : (<><span role="img" aria-label="cart">🛒</span> Add to Cart</>)}
       </AddToCartButton>
     </div>
   );
@@ -154,6 +154,7 @@ function StickyCartBar({
 
 export default function Product() {
   const {product} = useLoaderData<typeof loader>();
+  const {open} = useAside();
 
   // Optimistically selects a variant with given available variant information
   const selectedVariant = useOptimisticVariant(
@@ -184,25 +185,68 @@ export default function Product() {
         selectedVariantImage={selectedVariant?.image}
       />
       <div className="product-main">
-        <h1>{title}</h1>
-        <ReviewStars initialRating={4.8} />
-        <ProductPrice
-          price={selectedVariant?.price}
-          compareAtPrice={selectedVariant?.compareAtPrice}
-        />
-        <ProductForm
-          productOptions={productOptions}
-          selectedVariant={selectedVariant}
-        />
-        <p className="mt-2">
-          <a href="#size-modal" className="underline text-sm">View Size Guide</a>
-        </p>
-        <h2 className="text-lg font-bold">Description</h2>
-        <div className="mt-2" dangerouslySetInnerHTML={{__html: descriptionHtml}} />
-        <details className="mt-4">
-          <summary className="text-lg font-bold">Care Instructions</summary>
-          <p className="mt-2 text-sm">Hand wash cold, lay flat to dry. Do not bleach.</p>
-        </details>
+        <div className="space-y-2">
+          <h1 className="tracking-wide">{title}</h1>
+          <ReviewStars initialRating={4.8} />
+        </div>
+        <div className="mt-4 space-y-4">
+          <ProductPrice
+            price={selectedVariant?.price}
+            compareAtPrice={selectedVariant?.compareAtPrice}
+          />
+          <ProductForm
+            productOptions={productOptions}
+            selectedVariant={selectedVariant}
+          />
+          <AddToCartButton
+            disabled={!selectedVariant?.availableForSale}
+            onClick={() => open('cart')}
+            className="hidden lg:flex items-center justify-center gap-2 bg-orange-600 hover:bg-orange-700 text-white font-bold py-4 rounded-full transition-colors"
+            lines={
+              selectedVariant
+                ? [
+                    {
+                      merchandiseId: selectedVariant.id,
+                      quantity: 1,
+                      selectedVariant,
+                    },
+                  ]
+                : []
+            }
+          >
+            <span role="img" aria-label="cart">🛒</span> Add to Cart
+          </AddToCartButton>
+          <p className="mt-2">
+            <a href="#size-modal" className="underline text-sm">View Size Guide</a>
+          </p>
+        </div>
+        <div className="mt-8 space-y-4">
+          <details open className="border-t pt-4">
+            <summary className="font-bold flex items-center gap-2 cursor-pointer">
+              <span role="img" aria-label="Description">📄</span> Description
+            </summary>
+            <div
+              className="mt-2 text-sm leading-relaxed tracking-wide"
+              dangerouslySetInnerHTML={{__html: descriptionHtml}}
+            />
+          </details>
+          <details className="border-t pt-4">
+            <summary className="font-bold flex items-center gap-2 cursor-pointer">
+              <span role="img" aria-label="Care">🧼</span> Care instructions
+            </summary>
+            <p className="mt-2 text-sm leading-relaxed tracking-wide">
+              Hand wash cold, lay flat to dry. Do not bleach.
+            </p>
+          </details>
+          <details className="border-t pt-4">
+            <summary className="font-bold flex items-center gap-2 cursor-pointer">
+              <span role="img" aria-label="Shipping">🚚</span> Shipping info
+            </summary>
+            <p className="mt-2 text-sm leading-relaxed tracking-wide">
+              Ships worldwide in 3-5 business days.
+            </p>
+          </details>
+        </div>
       </div>
       <StickyCartBar selectedVariant={selectedVariant} />
       <Analytics.ProductView

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -3,6 +3,9 @@ html, body {
   padding: 0;
   width: 100%;
   overflow-x: hidden;
+  font-family: 'Inter', sans-serif;
+  line-height: 1.7;
+  letter-spacing: 0.02em;
 }
 
 *, *::before, *::after {
@@ -14,6 +17,11 @@ img, video {
   max-width: 100%;
   height: auto;
   display: block;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Poppins', 'Montserrat', sans-serif;
+  letter-spacing: 0.03em;
 }
 
 
@@ -517,6 +525,8 @@ button.reset:hover:not(:has(> *)) {
 
 .product h1 {
   margin-top: 0;
+  font-size: 2.5rem;
+  font-weight: 700;
 }
 
 .product-image img {
@@ -528,15 +538,21 @@ button.reset:hover:not(:has(> *)) {
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 500px;
+  width: 100%;
+  max-width: 500px;
   margin: 0 auto;
 }
 
 .gallery-main-image {
-  width: 500px;
+  width: 100%;
   height: 500px;
   object-fit: cover;
   margin-bottom: 0.75rem;
+  transition: transform 0.3s ease;
+}
+
+.gallery-main-image:hover {
+  transform: scale(1.05);
 }
 
 .gallery-thumbnails {
@@ -570,9 +586,9 @@ button.reset:hover:not(:has(> *)) {
   top: 6rem;
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.5rem;
   text-align: center;
-  width: 65%;
+  width: 100%;
 }
 
 .product-price-on-sale {
@@ -582,6 +598,12 @@ button.reset:hover:not(:has(> *)) {
 
 .product-price-on-sale s {
   opacity: 0.5;
+}
+
+.product-price {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #d97706;
 }
 
 .product-options-grid {
@@ -598,15 +620,23 @@ button.reset:hover:not(:has(> *)) {
 
 .product-options-item,
 .product-options-item:disabled {
-  padding: 0.25rem 0.5rem;
+  padding: 0.5rem 1rem;
   background-color: transparent;
   font-size: 1rem;
   font-family: inherit;
+  border: 1px solid #d1d5db;
+  border-radius: 9999px;
+  transition: all 0.2s ease;
+}
+.product-options-item:hover:not(:disabled) {
+  transform: scale(1.05);
 }
 .product-options-item.selected {
   border-color: #d4af37 !important;
-  background-image: linear-gradient(to bottom, #d4af37, #f5e18a);
+  background-image: none;
+  background-color: #000;
   color: #fff;
+  box-shadow: 0 0 0 2px #d4af37;
 }
 
 .product-option-label-swatch {
@@ -617,6 +647,23 @@ button.reset:hover:not(:has(> *)) {
 
 .product-option-label-swatch img {
   width: 100%;
+}
+
+@media (min-width: 1024px) {
+  .product {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: center;
+  }
+  .product-gallery {
+    max-width: 45%;
+    margin: 0;
+  }
+  .product-main {
+    width: 55%;
+    text-align: left;
+    padding-left: 2rem;
+  }
 }
 
 /*


### PR DESCRIPTION
## Summary
- Refresh typography by loading Inter, Poppins, and Montserrat fonts and applying them globally
- Redesign product page layout with responsive gallery/details split, zoomable images, pill-shaped size selectors, and accordions for description, care, and shipping info
- Enlarge and animate sticky Add to Cart bar with bright colors and cart icon for mobile and desktop

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 'cy' is not defined, 'expect' is not defined)*
- `npm run typecheck` *(fails: property 'loaderOptions' does not exist, other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_688b4a2970788326934b2b7a34230e5d