### PR TITLE
chore: remove care and shipping details

### DIFF
--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -128,7 +128,7 @@ export default function Product() {
         selectedVariantImage={selectedVariant?.image}
       />
       <div className="product-main">
-      <div className="space-y-2">
+        <div className="space-y-2">
           <h1 className="tracking-wide">{title}</h1>
           <ReviewStars initialRating={4.8} reviewCount={27} />
         </div>
@@ -179,16 +179,7 @@ export default function Product() {
                   : []
               }
             >
-              {added ? (
-                '✓ Added'
-              ) : (
-                <>
-                  <span role="img" aria-label="cart">
-                    🛒
-                  </span>{' '}
-                  Add to Cart
-                </>
-              )}
+              {added ? 'Added' : 'Add to Cart'}
             </AddToCartButton>
           </div>
           <p className="mt-2">
@@ -200,9 +191,6 @@ export default function Product() {
         <div className="mt-8 space-y-4">
           <details open className="border-t pt-4">
             <summary className="font-bold flex items-center gap-2 cursor-pointer">
-              <span role="img" aria-label="Description">
-                📄
-              </span>{' '}
               Description
             </summary>
             <div
@@ -210,35 +198,13 @@ export default function Product() {
               dangerouslySetInnerHTML={{__html: descriptionHtml}}
             />
           </details>
-          <details className="border-t pt-4">
-            <summary className="font-bold flex items-center gap-2 cursor-pointer">
-              <span role="img" aria-label="Care">
-                🧼
-              </span>{' '}
-              Care instructions
-            </summary>
-            <p className="mt-2 text-sm leading-relaxed tracking-wide">
-              Hand wash cold, lay flat to dry. Do not bleach.
-            </p>
-          </details>
-          <details className="border-t pt-4">
-            <summary className="font-bold flex items-center gap-2 cursor-pointer">
-              <span role="img" aria-label="Shipping">
-                🚚
-              </span>{' '}
-              Shipping info
-            </summary>
-            <p className="mt-2 text-sm leading-relaxed tracking-wide">
-              Ships worldwide in 3-5 business days.
-            </p>
-          </details>
         </div>
-        </div>
-        <Analytics.ProductView
-          data={{
-            products: [
-              {
-                id: product.id,
+      </div>
+      <Analytics.ProductView
+        data={{
+          products: [
+            {
+              id: product.id,
               title: product.title,
               price: selectedVariant?.price.amount || '0',
               vendor: product.vendor,

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -74,7 +74,6 @@
     <li role="tab" id="tab-label-desc" aria-controls="tab-desc" aria-selected="true" tabindex="0">Description</li>
     <li role="tab" id="tab-label-details" aria-controls="tab-details" aria-selected="false" tabindex="-1">Details</li>
     <li role="tab" id="tab-label-reviews" aria-controls="tab-reviews" aria-selected="false" tabindex="-1">Reviews</li>
-    <li role="tab" id="tab-label-shipping" aria-controls="tab-shipping" aria-selected="false" tabindex="-1">Shipping</li>
   </ul>
   <div id="tab-desc" role="tabpanel" aria-labelledby="tab-label-desc">
     <p>Product description content goes here.</p>
@@ -84,9 +83,6 @@
   </div>
   <div id="tab-reviews" role="tabpanel" aria-labelledby="tab-label-reviews" hidden>
     <p>Product reviews content goes here.</p>
-  </div>
-  <div id="tab-shipping" role="tabpanel" aria-labelledby="tab-label-shipping" hidden>
-    <p>Shipping information content goes here.</p>
   </div>
 </div>
 

--- a/snippets/tabs.liquid
+++ b/snippets/tabs.liquid
@@ -3,7 +3,6 @@
     <li role="tab" id="tab-label-desc" aria-controls="tab-desc" aria-selected="true" tabindex="0">Description</li>
     <li role="tab" id="tab-label-details" aria-controls="tab-details" aria-selected="false" tabindex="-1">Details</li>
     <li role="tab" id="tab-label-reviews" aria-controls="tab-reviews" aria-selected="false" tabindex="-1">Reviews</li>
-    <li role="tab" id="tab-label-shipping" aria-controls="tab-shipping" aria-selected="false" tabindex="-1">Shipping</li>
   </ul>
   <div id="tab-desc" role="tabpanel" aria-labelledby="tab-label-desc">
     <p>Product description content goes here.</p>
@@ -13,9 +12,6 @@
   </div>
   <div id="tab-reviews" role="tabpanel" aria-labelledby="tab-label-reviews" hidden>
     <p>Product reviews content goes here.</p>
-  </div>
-  <div id="tab-shipping" role="tabpanel" aria-labelledby="tab-label-shipping" hidden>
-    <p>Shipping information content goes here.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- remove care instructions and shipping details from product view
- drop shipping tab from Liquid templates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: parsing errors in generated files)*
- `npm run typecheck` *(fails: type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_688bb345a6dc8326870bc20f91ab2384