### PR TITLE
feat: darken product price color

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -604,7 +604,7 @@ button.reset:hover:not(:has(> *)) {
 .product-price {
   font-size: 1.75rem;
   font-weight: 700;
-  color: #d97706;
+  color: #b45309;
 }
 
 .product-options-grid {


### PR DESCRIPTION
## Summary
- darken product price color for better contrast

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 416 errors, 37 warnings)*
- `npm run typecheck` *(fails: Type errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bb58baf14832698311fbe9f63db21