### PR TITLE
Remove review count link

### DIFF
--- a/app/components/ReviewStars.tsx
+++ b/app/components/ReviewStars.tsx
@@ -3,16 +3,10 @@ import {motion} from 'framer-motion';
 
 interface ReviewStarsProps {
   initialRating?: number;
-  /**
-   * Total number of reviews to display alongside the rating. When omitted, the
-   * review count link is hidden.
-   */
-  reviewCount?: number;
 }
 
 export function ReviewStars({
   initialRating = 0,
-  reviewCount,
 }: ReviewStarsProps) {
   const [rating, setRating] = useState(Math.round(initialRating));
   const [hover, setHover] = useState(0);
@@ -35,11 +29,6 @@ export function ReviewStars({
           ★
         </motion.span>
       ))}
-      {typeof reviewCount === 'number' && (
-        <a href="#reviews" className="underline ml-2 text-sm">
-          Read {reviewCount} Review{reviewCount === 1 ? '' : 's'}
-        </a>
-      )}
     </div>
   );
 }

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -130,7 +130,7 @@ export default function Product() {
       <div className="product-main">
         <div className="space-y-2">
           <h1 className="tracking-wide">{title}</h1>
-          <ReviewStars initialRating={4.8} reviewCount={27} />
+          <ReviewStars initialRating={4.8} />
         </div>
         <div className="mt-4 space-y-4">
           <ProductPrice


### PR DESCRIPTION
## Summary
- remove "Read 27 Reviews" link from star rating component
- stop passing review count to product page star component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: lint errors in dist files)*
- `npm run typecheck` *(fails: existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bb6f7773c8326a44a24dbeda88c0d