### PR TITLE
feat: add sliding size guide panel

### DIFF
--- a/app/components/SizeGuideModal.tsx
+++ b/app/components/SizeGuideModal.tsx
@@ -1,105 +1,66 @@
-import {useEffect, useRef} from 'react';
+import {useEffect, useState} from 'react';
 
 export function SizeGuideModal() {
-  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [open, setOpen] = useState(false);
 
-  // open dialog when clicking anchor link
+  // open panel when clicking anchor link
   useEffect(() => {
     function handleClick(event: MouseEvent) {
       const target = event.target as HTMLElement;
       if (target && target.closest('a[href="#size-modal"]')) {
         event.preventDefault();
-        dialogRef.current?.showModal();
-        const first = dialogRef.current?.querySelector<HTMLElement>('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-        first?.focus();
+        setOpen(true);
       }
     }
     document.addEventListener('click', handleClick);
     return () => document.removeEventListener('click', handleClick);
   }, []);
 
-  // focus trap inside dialog
+  // allow closing with escape key
   useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    function trap(event: KeyboardEvent) {
-      if (event.key !== 'Tab' || !dialog.open) return;
-      const elements = dialog.querySelectorAll<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-      );
-      if (!elements.length) return;
-      const first = elements[0];
-      const last = elements[elements.length - 1];
-      if (event.shiftKey) {
-        if (document.activeElement === first) {
-          event.preventDefault();
-          last.focus();
-        }
-      } else if (document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false);
     }
-    dialog.addEventListener('keydown', trap);
-    return () => dialog.removeEventListener('keydown', trap);
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
   }, []);
 
   return (
-    <dialog id="size-modal" ref={dialogRef} aria-labelledby="size-modal-title">
-      <button className="close" aria-label="Close" onClick={() => dialogRef.current?.close()}>
-        ✕
-      </button>
-      <h2 id="size-modal-title" className="font-['Playfair_Display'] text-[20px] mb-4">
-        Size Guide
-      </h2>
-      <table className="w-full text-left border-collapse">
-        <thead>
-          <tr>
-            <th>Size</th>
-            <th>Bust</th>
-            <th>Waist</th>
-            <th>Hip</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">XS</th>
-            <td>32"</td>
-            <td>24"</td>
-            <td>34"</td>
-          </tr>
-          <tr>
-            <th scope="row">S</th>
-            <td>34"</td>
-            <td>26"</td>
-            <td>36"</td>
-          </tr>
-          <tr>
-            <th scope="row">M</th>
-            <td>36"</td>
-            <td>28"</td>
-            <td>38"</td>
-          </tr>
-          <tr>
-            <th scope="row">L</th>
-            <td>38"</td>
-            <td>30"</td>
-            <td>40"</td>
-          </tr>
-          <tr>
-            <th scope="row">XL</th>
-            <td>40"</td>
-            <td>32"</td>
-            <td>42"</td>
-          </tr>
-          <tr>
-            <th scope="row">XXL</th>
-            <td>42"</td>
-            <td>34"</td>
-            <td>44"</td>
-          </tr>
-        </tbody>
-      </table>
-    </dialog>
+    <>
+      {open && (
+        <button
+          type="button"
+          aria-label="Close"
+          className="fixed inset-0 bg-black/50 z-40"
+          onClick={() => setOpen(false)}
+        />
+      )}
+      <aside
+        id="size-modal"
+        aria-labelledby="size-modal-title"
+        className={`fixed top-0 right-0 h-full w-80 max-w-full bg-white shadow-lg z-50 transform transition-transform duration-500 ease-in-out ${
+          open ? 'translate-x-0' : 'translate-x-full invisible pointer-events-none'
+        }`}
+      >
+        <button
+          className="close absolute top-4 right-4 text-2xl"
+          aria-label="Close"
+          onClick={() => setOpen(false)}
+        >
+          ✕
+        </button>
+        <h2
+          id="size-modal-title"
+          className="font-['Playfair_Display'] text-[20px] mb-4 mt-8 text-center"
+        >
+          Size Guide
+        </h2>
+        <img
+          src="/size-guide.svg"
+          alt="Size guide chart"
+          className="w-full h-auto px-4 pb-4"
+        />
+      </aside>
+    </>
   );
 }

--- a/cypress/e2e/product_page_spec.js
+++ b/cypress/e2e/product_page_spec.js
@@ -1,3 +1,5 @@
+/* global describe, beforeEach, cy, it, expect */
+
 describe('Limelight Yarn-Dyed Embroidered Shirt page', () => {
   beforeEach(() => {
     cy.viewport(1280, 800);
@@ -75,14 +77,11 @@ describe('Limelight Yarn-Dyed Embroidered Shirt page', () => {
       expect($badges.eq(2)).to.contain.text('Easy Care');
     });
 
-    // Size guide modal
-    cy.log('Open and close size guide modal');
+    // Size guide panel
+    cy.log('Open and close size guide panel');
     cy.contains('a', 'View Size Guide').click();
     cy.get('#size-modal').should('be.visible').within(() => {
-      const sizes = ['XS', 'S', 'M', 'L', 'XL', 'XXL'];
-      sizes.forEach((size) => {
-        cy.contains('th', size).should('exist');
-      });
+      cy.get('img[alt="Size guide chart"]').should('exist');
       cy.get('button.close').click();
     });
     cy.get('#size-modal').should('not.be.visible');

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ export default [
     ignores: [
       '**/node_modules/',
       '**/build/',
+      '**/dist/',
       '**/*.graphql.d.ts',
       '**/*.graphql.ts',
       '**/*.generated.d.ts',

--- a/public/size-guide.svg
+++ b/public/size-guide.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="220">
+  <style>
+    .title { font: bold 18px 'Playfair Display', serif; }
+    .header { font-weight: bold; }
+    text { font: 14px sans-serif; }
+  </style>
+  <rect x="0" y="0" width="400" height="220" fill="white" stroke="#ccc" />
+  <text x="200" y="25" text-anchor="middle" class="title">Size Guide</text>
+  <text x="20" y="60" class="header">Size</text>
+  <text x="90" y="60" class="header">Bust</text>
+  <text x="160" y="60" class="header">Waist</text>
+  <text x="230" y="60" class="header">Hip</text>
+  <text x="20" y="85">XS</text>
+  <text x="90" y="85">32"</text>
+  <text x="160" y="85">24"</text>
+  <text x="230" y="85">34"</text>
+  <text x="20" y="105">S</text>
+  <text x="90" y="105">34"</text>
+  <text x="160" y="105">26"</text>
+  <text x="230" y="105">36"</text>
+  <text x="20" y="125">M</text>
+  <text x="90" y="125">36"</text>
+  <text x="160" y="125">28"</text>
+  <text x="230" y="125">38"</text>
+  <text x="20" y="145">L</text>
+  <text x="90" y="145">38"</text>
+  <text x="160" y="145">30"</text>
+  <text x="230" y="145">40"</text>
+  <text x="20" y="165">XL</text>
+  <text x="90" y="165">40"</text>
+  <text x="160" y="165">32"</text>
+  <text x="230" y="165">42"</text>
+  <text x="20" y="185">XXL</text>
+  <text x="90" y="185">42"</text>
+  <text x="160" y="185">34"</text>
+  <text x="230" y="185">44"</text>
+</svg>


### PR DESCRIPTION
## Summary
- animate size guide from side with smooth sliding drawer and SVG chart
- add Cypress coverage for new panel
- ignore dist directory during linting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint app/components/SizeGuideModal.tsx cypress/e2e/product_page_spec.js`
- `npm run typecheck` *(fails: TS2322, TS2305, TS2307)*

------
https://chatgpt.com/codex/tasks/task_e_688bb90f56bc8326a16499d83ea513b4