### PR TITLE
Reduce spacing in product page right section

### DIFF
--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -128,11 +128,11 @@ export default function Product() {
         selectedVariantImage={selectedVariant?.image}
       />
       <div className="product-main">
-        <div className="space-y-2">
+        <div className="space-y-1">
           <h1 className="tracking-wide">{title}</h1>
           <ReviewStars initialRating={4.8} />
         </div>
-        <div className="mt-4 space-y-4">
+        <div className="space-y-1">
           <ProductPrice
             price={selectedVariant?.price}
             compareAtPrice={selectedVariant?.compareAtPrice}
@@ -141,7 +141,7 @@ export default function Product() {
             productOptions={productOptions}
             selectedVariant={selectedVariant}
           />
-          <div className="space-y-4">
+          <div className="space-y-1">
             <div className="flex items-center border border-[#d4af37] rounded">
               <button
                 type="button"
@@ -182,13 +182,13 @@ export default function Product() {
               {added ? 'Added' : 'Add to Cart'}
             </AddToCartButton>
           </div>
-          <p className="mt-2">
+          <p className="mt-1">
             <a href="#size-modal" className="underline text-sm">
               View Size Guide
             </a>
           </p>
         </div>
-        <div className="mt-8 space-y-4">
+        <div className="mt-2 space-y-1">
           <details open className="border-t pt-4">
             <summary className="font-bold flex items-center gap-2 cursor-pointer">
               Description

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -587,7 +587,7 @@ button.reset:hover:not(:has(> *)) {
   top: 6rem;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 0.5rem;
   text-align: center;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- tighten spacing between blocks on product page right column
- adjust styles to use smaller gaps for cleaner layout

## Testing
- `npm run lint` *(fails: no-unused-vars, react-hooks/rules-of-hooks)*
- `npm run typecheck` *(fails: Type '{ data: { url: string; altText?: string | null | undefined; }; className: string; loading: "eager"; width: number; height: number; sizes: string; loaderOptions: { format: string; }; fetchpriority: string; onClick: () => void; style: { ...; }; }' is not assignable to type ...)*

------
https://chatgpt.com/codex/tasks/task_e_688bbe185d048326a00eb1db14a1ee52