### PR TITLE
fix: remove hover underline on hero button

### DIFF
--- a/app/routes/($locale)._index.tsx
+++ b/app/routes/($locale)._index.tsx
@@ -89,7 +89,7 @@ function BannerCarousel() {
       <div className="absolute bottom-16 right-1 -translate-x-1/2">
         <Link
           to="/collections/all"
-          className="px-12 py-6 text-white rounded-full shadow-lg bg-gradient-to-r from-[#d4af37] via-[#f5e18a] to-[#d4af37] hover:opacity-90"
+          className="px-12 py-6 text-white rounded-full shadow-lg bg-gradient-to-r from-[#d4af37] via-[#f5e18a] to-[#d4af37] hover:opacity-90 no-underline hover:no-underline"
         >
           Explore Collection
         </Link>


### PR DESCRIPTION
## Summary
- prevent underline on hover for Explore Collection button on homepage hero

## Testing
- `npm run lint` *(fails: many lint errors in dist files)*
- `npx eslint app/routes/($locale)._index.tsx`
- `npm run typecheck` *(fails: type errors in components and server)*

------
https://chatgpt.com/codex/tasks/task_e_688bc76901788326b5c6a0e9e9e19a42