### PR TITLE
Fix brand item hover spacing

### DIFF
--- a/app/routes/($locale).collections._index.tsx
+++ b/app/routes/($locale).collections._index.tsx
@@ -72,23 +72,24 @@ function CollectionItem({
   index: number;
 }) {
   return (
-    <Link
-      className="collection-item"
-      key={collection.id}
-      to={`/collections/${collection.handle}`}
-      prefetch="intent"
-    >
-      {collection?.image && (
-        <Image
-          alt={collection.image.altText || collection.title}
-          aspectRatio="1/1"
-          data={collection.image}
-          loading={index < 3 ? 'eager' : undefined}
-          sizes="(min-width: 45em) 400px, 100vw"
-        />
-      )}
+    <div key={collection.id} className="collection-item">
+      <Link
+        className="block no-underline hover:no-underline"
+        to={`/collections/${collection.handle}`}
+        prefetch="intent"
+      >
+        {collection?.image && (
+          <Image
+            alt={collection.image.altText || collection.title}
+            aspectRatio="1/1"
+            data={collection.image}
+            loading={index < 3 ? 'eager' : undefined}
+            sizes="(min-width: 45em) 400px, 100vw"
+          />
+        )}
+      </Link>
       <h5>{collection.title}</h5>
-    </Link>
+    </div>
   );
 }
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -474,6 +474,7 @@ button.reset:hover:not(:has(> *)) {
 }
 
 .collection-item img {
+  display: block;
   height: auto;
 }
 


### PR DESCRIPTION
## Summary
- Only show collection image as the link so text doesn't underline
- Remove trailing whitespace beneath brand images

## Testing
- `npm run lint` *(fails: 462 problems (424 errors, 38 warnings))*
- `npm run typecheck` *(fails: Cannot find module 'virtual:react-router/server-build')*

------
https://chatgpt.com/codex/tasks/task_e_688bdbb4d8c88326ad8d9316f2cbed5a