### PR TITLE
Fix brand and product card hover spacing

### DIFF
--- a/app/components/ProductItem.tsx
+++ b/app/components/ProductItem.tsx
@@ -20,35 +20,37 @@ export function ProductItem({
   const hoverImage = images?.[1];
 
   return (
-    <Link
-      to={variantUrl}
-      prefetch="intent"
-      className="group block bg-[#f9f5ee] rounded-lg shadow-sm hover:shadow-md transition overflow-hidden hover:no-underline"
-    >
-      {primaryImage && (
-        <div className="relative aspect-[3/4] bg-gray-50 overflow-hidden">
-          <Image
-            alt={primaryImage.altText || product.title}
-            aspectRatio="1/1"
-            data={primaryImage}
-            loading={loading}
-            sizes="(min-width: 45em) 400px, 100vw"
-            className={`object-cover w-full h-full transition-all duration-300 ${
-              hoverImage ? 'group-hover:opacity-0' : 'group-hover:scale-105'
-            }`}
-          />
-          {hoverImage && (
+    <div className="product-item group bg-[#f9f5ee] rounded-lg shadow-sm hover:shadow-md transition overflow-hidden">
+      <Link
+        to={variantUrl}
+        prefetch="intent"
+        className="block no-underline hover:no-underline"
+      >
+        {primaryImage && (
+          <div className="relative aspect-[3/4] bg-gray-50 overflow-hidden">
             <Image
-              alt={hoverImage.altText || product.title}
+              alt={primaryImage.altText || product.title}
               aspectRatio="1/1"
-              data={hoverImage}
+              data={primaryImage}
               loading={loading}
               sizes="(min-width: 45em) 400px, 100vw"
-              className="object-cover w-full h-full absolute inset-0 opacity-0 transition-all duration-300 group-hover:opacity-100 group-hover:scale-105"
+              className={`object-cover w-full h-full transition-all duration-300 ${
+                hoverImage ? 'group-hover:opacity-0' : 'group-hover:scale-105'
+              }`}
             />
-          )}
-        </div>
-      )}
+            {hoverImage && (
+              <Image
+                alt={hoverImage.altText || product.title}
+                aspectRatio="1/1"
+                data={hoverImage}
+                loading={loading}
+                sizes="(min-width: 45em) 400px, 100vw"
+                className="object-cover w-full h-full absolute inset-0 opacity-0 transition-all duration-300 group-hover:opacity-100 group-hover:scale-105"
+              />
+            )}
+          </div>
+        )}
+      </Link>
 
       <div className="p-4">
         <h4 className="text-sm font-medium text-gray-800 line-clamp-2">
@@ -58,6 +60,6 @@ export function ProductItem({
           <Money data={product.priceRange.minVariantPrice} />
         </p>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/app/routes/($locale).collections._index.tsx
+++ b/app/routes/($locale).collections._index.tsx
@@ -72,23 +72,24 @@ function CollectionItem({
   index: number;
 }) {
   return (
-    <Link
-      className="collection-item"
-      key={collection.id}
-      to={`/collections/${collection.handle}`}
-      prefetch="intent"
-    >
-      {collection?.image && (
-        <Image
-          alt={collection.image.altText || collection.title}
-          aspectRatio="1/1"
-          data={collection.image}
-          loading={index < 3 ? 'eager' : undefined}
-          sizes="(min-width: 45em) 400px, 100vw"
-        />
-      )}
+    <div key={collection.id} className="collection-item">
+      <Link
+        className="block no-underline hover:no-underline"
+        to={`/collections/${collection.handle}`}
+        prefetch="intent"
+      >
+        {collection?.image && (
+          <Image
+            alt={collection.image.altText || collection.title}
+            aspectRatio="1/1"
+            data={collection.image}
+            loading={index < 3 ? 'eager' : undefined}
+            sizes="(min-width: 45em) 400px, 100vw"
+          />
+        )}
+      </Link>
       <h5>{collection.title}</h5>
-    </Link>
+    </div>
   );
 }
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -474,6 +474,7 @@ button.reset:hover:not(:has(> *)) {
 }
 
 .collection-item img {
+  display: block;
   height: auto;
 }
 
@@ -500,6 +501,7 @@ button.reset:hover:not(:has(> *)) {
 .product-item img {
   height: auto;
   width: 100%;
+  display: block;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Only show collection and product images as links so text stays unstyled
- Render collection and product images as block elements to remove gaps

## Testing
- `npm run lint` *(fails: 462 problems (424 errors, 38 warnings))*
- `npm run typecheck` *(fails: Cannot find module 'virtual:react-router/server-build')*


------
https://chatgpt.com/codex/tasks/task_e_688bdbb4d8c88326ad8d9316f2cbed5a