### PR TITLE
Fix extra spacing on collection product cards

### DIFF
--- a/app/components/ProductItem.tsx
+++ b/app/components/ProductItem.tsx
@@ -52,7 +52,7 @@ export function ProductItem({
         )}
       </Link>
 
-      <div className="p-4">
+      <div className="px-4 pt-2 pb-4">
         <h4 className="text-sm font-medium text-gray-800 line-clamp-2">
           {product.title}
         </h4>


### PR DESCRIPTION
## Summary
- tighten padding on product cards so title and price sit closer to the image

## Testing
- `npm run lint` *(fails: 'u' is defined but never used, etc.)*
- `npm run typecheck` *(fails: Cannot find module 'virtual:react-router/server-build')*


------
https://chatgpt.com/codex/tasks/task_e_688bea1fcba083269341d118edede869