### PR TITLE
Reposition zoom preview in product gallery

### DIFF
--- a/app/components/ProductGallery.tsx
+++ b/app/components/ProductGallery.tsx
@@ -90,17 +90,6 @@ export function ProductGallery({
               onClick={() => setLightboxOpen(true)}
               style={{cursor: 'zoom-in'}}
             />
-            {zoomPos && (
-              <div
-                className="hidden md:block absolute top-0 left-full ml-4 w-64 h-64 border rounded bg-white overflow-hidden"
-                style={{
-                  backgroundImage: `url(${mainImage.url})`,
-                  backgroundPosition: `${zoomPos.x}% ${zoomPos.y}%`,
-                  backgroundRepeat: 'no-repeat',
-                  backgroundSize: '200% 200%',
-                }}
-              />
-            )}
           </motion.div>
         </AnimatePresence>
       )}
@@ -116,6 +105,17 @@ export function ProductGallery({
           </button>
         ))}
       </div>
+      {zoomPos && mainImage && (
+        <div
+          className="hidden md:block mt-4 w-64 h-64 border rounded bg-white overflow-hidden self-start"
+          style={{
+            backgroundImage: `url(${mainImage.url})`,
+            backgroundPosition: `${zoomPos.x}% ${zoomPos.y}%`,
+            backgroundRepeat: 'no-repeat',
+            backgroundSize: '200% 200%',
+          }}
+        />
+      )}
       {lightboxOpen && (
         <div
           className="lightbox-overlay"


### PR DESCRIPTION
## Summary
- show zoom preview beneath gallery thumbnails and align left

## Testing
- `npm run lint` *(fails: 459 problems)*
- `npx eslint app/components/ProductGallery.tsx`
- `npm run typecheck` *(fails: Cannot find module 'virtual:react-router/server-build')*


------
https://chatgpt.com/codex/tasks/task_e_688c0ca420588326a28e70cc0a6460b2