### PR TITLE
Show product description without toggle

### DIFF
--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -189,15 +189,13 @@ export default function Product() {
           </p>
         </div>
         <div className="mt-2 space-y-1">
-          <details open className="border-t pt-4">
-            <summary className="font-bold flex items-center gap-2 cursor-pointer">
-              Description
-            </summary>
+          <div className="border-t pt-4">
+            <h2 className="font-bold flex items-center gap-2">Description</h2>
             <div
               className="mt-2 text-sm leading-relaxed tracking-wide"
               dangerouslySetInnerHTML={{__html: descriptionHtml}}
             />
-          </details>
+          </div>
         </div>
       </div>
       <Analytics.ProductView


### PR DESCRIPTION
## Summary
- remove `<details>` toggle from product page description and display content persistently

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 421 errors, 38 warnings)*
- `npm run typecheck` *(fails: Cannot find module 'virtual:react-router/server-build')*

------
https://chatgpt.com/codex/tasks/task_e_688c0f956de08326be5ac31e61b7aad1