### PR TITLE
Style sort dropdown with dark brown theme

### DIFF
--- a/app/routes/($locale).collections.$handle.tsx
+++ b/app/routes/($locale).collections.$handle.tsx
@@ -100,7 +100,7 @@ export default function Collection() {
           </div>
           <div>
             <select
-              className="px-4 py-2 rounded-full border border-[#d4af37] bg-gradient-to-r from-[#d4af37] via-[#f5e18a] to-[#d4af37] text-white font-medium shadow-md focus:outline-none"
+              className="px-4 py-2 rounded-full border border-[#4b3621] bg-[#4b3621] text-white font-medium shadow-md hover:bg-[#5e472a] focus:outline-none"
               value={sortOption}
               onChange={(e) => setSortOption(e.target.value)}
             >

--- a/app/routes/($locale).collections.all.tsx
+++ b/app/routes/($locale).collections.all.tsx
@@ -97,7 +97,7 @@ export default function Collection() {
           </div>
           <div>
             <select
-              className="px-4 py-2 rounded-full border border-[#d4af37] bg-gradient-to-r from-[#d4af37] via-[#f5e18a] to-[#d4af37] text-white font-medium shadow-md focus:outline-none"
+              className="px-4 py-2 rounded-full border border-[#4b3621] bg-[#4b3621] text-white font-medium shadow-md hover:bg-[#5e472a] focus:outline-none"
               value={sortOption}
               onChange={(e) => setSortOption(e.target.value)}
             >


### PR DESCRIPTION
## Summary
- style collection sort dropdown to use dark brown text and border matching page titles
- tint sort dropdown background with dark brown and white text so it stands out

## Testing
- `npx eslint 'app/routes/($locale).collections.$handle.tsx' 'app/routes/($locale).collections.all.tsx'`
- `npm run typecheck` *(fails: Cannot find module 'virtual:react-router/server-build')*


------
https://chatgpt.com/codex/tasks/task_e_688c251387ac83268db938842569b4ee