### PR TITLE
feat: make product image fill column

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -2,9 +2,9 @@
 <main>
   <section id="product-hero" class="grid grid-cols-1 md:grid-cols-2 gap-8">
     <!-- Left: initialize Slick.js slider for main image + thumbnails -->
-    <div>
+    <div class="w-full">
       <!-- Slick.js main image slider -->
-      <div class="product-slider-main">
+      <div class="product-slider-main w-full">
         <img src="/path/to/product-image.jpg" alt="Product image" class="w-full h-auto" />
       </div>
       <!-- Slick.js thumbnails -->


### PR DESCRIPTION
## Summary
- ensure product page slider and container span full width of left column

## Testing
- `npm run lint` *(fails: eslint errors across dist/ files)*
- `npm run typecheck` *(fails: Cannot find module 'virtual:react-router/server-build')*


------
https://chatgpt.com/codex/tasks/task_e_688c3268b14483268b25d7c1639357e6